### PR TITLE
Add Auto Splitter for Anno 1602: History Edition

### DIFF
--- a/Anno1602.asl
+++ b/Anno1602.asl
@@ -1,0 +1,37 @@
+state("Anno1602") {
+    byte startFlag : "Anno1602.exe", 0x5C4ECC;
+    byte stopFlag  : "Anno1602.exe", 0x5F10E0;
+}
+
+startup {
+    settings.Add("start", true, "Start when startFlag changes from 7 to 0");
+    settings.Add("stop", true, "Stop when stopFlag changes from 12 to 9");
+}
+
+start {
+    return old.startFlag == 7 && current.startFlag == 0;
+}
+
+split {
+    return false; // Kein Zwischen-Split
+}
+
+reset {
+    return false; // Kein Auto-Reset
+}
+
+stop {
+    return old.stopFlag == 12 && current.stopFlag == 9;
+}
+
+isLoading {
+    return false; // Keine Ladezeiten-Erkennung
+}
+
+gameTime {
+    return 0;
+}
+
+update {
+    // Keine weitere Logik nötig
+}


### PR DESCRIPTION
If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [x] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [x] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [x] The Auto Splitter has an open source license that allows anyone to fork and host it.

This Auto Splitter supports Anno 1602: History Edition (Ubisoft Connect) and adds:
- Auto start when startFlag changes from 7 → 0
- Auto stop when stopFlag changes from 12 → 9

Memory addresses:
- startFlag: 0x5C4ECC (byte)
- stopFlag: 0x5F10E0 (int)

Verified with:
- Anno 1602 History Edition (Ubisoft Connect)
- LiveSplit 1.8.33
- Windows 11

Created by: invuln3r4bl3
